### PR TITLE
Add new optional query string parameter for excludedTags

### DIFF
--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Document.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Document.cs
@@ -80,7 +80,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
         }
 #endif
         /// <inheritdoc />
-        public IDocument Build(Assembly assembly, NamingStrategy namingStrategy = null)
+        public IDocument Build(Assembly assembly, NamingStrategy namingStrategy = null, string[] excludedTags = null)
         {
             if (namingStrategy.IsNullOrDefault())
             {
@@ -89,7 +89,7 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
 
             var paths = new OpenApiPaths();
 
-            var methods = this._helper.GetHttpTriggerMethods(assembly);
+            var methods = this._helper.GetHttpTriggerMethods(assembly, excludedTags);
             foreach (var method in methods)
             {
                 var trigger = this._helper.GetHttpTriggerAttribute(method);

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/DocumentHelper.cs
@@ -36,12 +36,13 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi
         }
 
         /// <inheritdoc />
-        public List<MethodInfo> GetHttpTriggerMethods(Assembly assembly)
+        public List<MethodInfo> GetHttpTriggerMethods(Assembly assembly, string[] excludedTags)
         {
             var methods = assembly.GetTypes()
                                   .SelectMany(p => p.GetMethods())
                                   .Where(p => p.ExistsCustomAttribute<FunctionNameAttribute>())
                                   .Where(p => p.ExistsCustomAttribute<OpenApiOperationAttribute>())
+                                  .Where(p => !p.HasOpenApiOperationTagsAttribute(excludedTags))
                                   .Where(p => !p.ExistsCustomAttribute<OpenApiIgnoreAttribute>())
                                   .Where(p => p.GetParameters().FirstOrDefault(q => q.ExistsCustomAttribute<HttpTriggerAttribute>()) != null)
                                   .ToList();

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/MemberInfoExtensions.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/Extensions/MemberInfoExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Aliencube.AzureFunctions.Extensions.OpenApi.Attributes;
+using System;
 using System.Reflection;
+using System.Linq;
 
 namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
 {
@@ -22,6 +24,24 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Extensions
             var exists = element.GetCustomAttribute<T>(inherit) != null;
 
             return exists;
+        }
+
+        /// <summary>
+        /// Checks if <see cref="OpenApiOperationAttribute"/> has particular tags.
+        /// </summary>
+        /// <param name="element"><see cref="MemberInfo"/> instance.</param>
+        /// <param name="tags">Tags to search for.</param>
+        /// <param name="inherit">Value indicating whether to inspect ancestors or not. Default is <c>false</c>.</param>
+        /// <returns><c>true</c>, if tags are found; otherwise returns <c>false</c>.</returns>
+        public static bool HasOpenApiOperationTagsAttribute(this MemberInfo element, string[] tags, bool inherit = false)
+        {
+            element.ThrowIfNullOrDefault();
+
+            var attr = element.GetCustomAttribute<OpenApiOperationAttribute>(inherit);
+
+            bool result = attr.Tags.Any(el => tags != null && tags.Contains(el));
+
+            return result;
         }
     }
 }

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocument.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocument.cs
@@ -56,8 +56,9 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Abstractions
         /// </summary>
         /// <param name="assembly"><see cref="Assembly"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
+        /// <param name="excludedTags">List of tags to exclude from document.</param>
         /// <returns><see cref="IDocument"/> instance.</returns>
-        IDocument Build(Assembly assembly, NamingStrategy namingStrategy = null);
+        IDocument Build(Assembly assembly, NamingStrategy namingStrategy = null, string[] excludedTags = null);
 
         /// <summary>
         /// Renders Open API document.

--- a/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocumentHelper.cs
+++ b/src/Aliencube.AzureFunctions.Extensions.OpenApi/IDocumentHelper.cs
@@ -17,8 +17,9 @@ namespace Aliencube.AzureFunctions.Extensions.OpenApi.Abstractions
         /// Gets the list of HTTP triggers.
         /// </summary>
         /// <param name="assembly">Assembly of Azure Function instance.</param>
+        /// <param name="excludedTags">List of tags to exclude from document.</param>
         /// <returns>List of <see cref="MethodInfo"/> instances representing HTTP triggers.</returns>
-        List<MethodInfo> GetHttpTriggerMethods(Assembly assembly);
+        List<MethodInfo> GetHttpTriggerMethods(Assembly assembly, string[] excludedTags);
 
         /// <summary>
         /// Gets the <see cref="FunctionNameAttribute"/> from the method.

--- a/src/Aliencube.AzureFunctions.FunctionAppCommon/Functions/FunctionOptions/RenderOpeApiDocumentFunctionOptions.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppCommon/Functions/FunctionOptions/RenderOpeApiDocumentFunctionOptions.cs
@@ -18,11 +18,12 @@ namespace Aliencube.AzureFunctions.FunctionAppCommon.Functions.FunctionOptions
         /// <param name="version">Open API version. This MUST be either "v2" or "v3".</param>
         /// <param name="format">Open API document format. This MUST be either "json" or "yaml".</param>
         /// <param name="assembly">Function app assembly.</param>
-        public RenderOpeApiDocumentFunctionOptions(string version, string format, Assembly assembly)
+        public RenderOpeApiDocumentFunctionOptions(string version, string format, Assembly assembly, string[] excludedTags)
         {
             this.Version = this.GetVersion(version);
             this.Format = this.GetFormat(format);
             this.Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+            this.ExcludedTags = excludedTags;
         }
 
         /// <summary>
@@ -39,6 +40,8 @@ namespace Aliencube.AzureFunctions.FunctionAppCommon.Functions.FunctionOptions
         /// Gets or sets the <see cref="System.Reflection.Assembly"/> instance.
         /// </summary>
         public Assembly Assembly { get; set; }
+
+        public string[] ExcludedTags { get; set; }
 
         private OpenApiSpecVersion GetVersion(string version)
         {

--- a/src/Aliencube.AzureFunctions.FunctionAppCommon/Functions/RenderOpeApiDocumentFunction.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppCommon/Functions/RenderOpeApiDocumentFunction.cs
@@ -66,7 +66,7 @@ namespace Aliencube.AzureFunctions.FunctionAppCommon.Functions
                                    .InitialiseDocument()
                                    .AddMetadata(this._settings.OpenApiInfo)
                                    .AddServer(req, this._settings.HttpSettings.RoutePrefix)
-                                   .Build(opt.Assembly)
+                                   .Build(opt.Assembly, null, opt.ExcludedTags)
                                    .RenderAsync(opt.Version, opt.Format)
                                    .ConfigureAwait(false);
 

--- a/src/Aliencube.AzureFunctions.FunctionAppV1/OpenApiHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV1/OpenApiHttpTrigger.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Linq;
 
 using Aliencube.AzureFunctions.Extensions.DependencyInjection;
 using Aliencube.AzureFunctions.Extensions.DependencyInjection.Abstractions;
@@ -11,6 +12,7 @@ using Aliencube.AzureFunctions.FunctionAppCommon.Functions.FunctionOptions;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Aliencube.AzureFunctions.FunctionAppV1
 {
@@ -36,7 +38,7 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger.json")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v2", "json", Assembly.GetExecutingAssembly());
+            var options = new RenderOpeApiDocumentFunctionOptions("v2", "json", Assembly.GetExecutingAssembly(), null);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -56,7 +58,9 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger.yaml")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v2", "yaml", Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+
+            var options = new RenderOpeApiDocumentFunctionOptions("v2", "yaml", Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -76,7 +80,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "openapi/v2.json")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v2", "json", Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions("v2", "json", Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -96,7 +101,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "openapi/v2.yaml")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v2", "yaml", Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions("v2", "yaml", Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -116,7 +122,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "openapi/v3.json")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v3", "json", Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions("v3", "json", Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -136,7 +143,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "openapi/v3.yaml")] HttpRequestMessage req,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v3", "yaml", Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions("v3", "yaml", Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req, options)
                                       .ConfigureAwait(false);
@@ -162,6 +170,19 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
                                       .ConfigureAwait(false);
 
             return result;
+        }
+
+        private static string[] GetExcludedTagsFromQueryString(HttpRequestMessage req)
+        {
+            string[] excludedTags = null;
+
+            var value = req.GetQueryNameValuePairs().FirstOrDefault(p => p.Key.Equals("excludedTags", System.StringComparison.InvariantCultureIgnoreCase)).Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                excludedTags = value.Split(',');
+            }
+
+            return excludedTags;
         }
     }
 }

--- a/src/Aliencube.AzureFunctions.FunctionAppV1/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV1/SampleHttpTrigger.cs
@@ -51,6 +51,24 @@ namespace Aliencube.AzureFunctions.FunctionAppV1
         }
 
         /// <summary>
+        /// Invokes the HTTP trigger endpoint to get sample but exclude from tags.
+        /// </summary>
+        /// <param name="req"><see cref="HttpRequest"/> instance.</param>
+        /// <param name="log"><see cref="ILogger"/> instance.</param>
+        [FunctionName(nameof(GetSampleExclude))]
+        [OpenApiOperation(operationId: "exclude", tags: new[] { "exclude" }, Summary = "Used for tag exclusion", Description = "Used for tag exclusion.", Visibility = OpenApiVisibilityType.Important)]
+        public static async Task<HttpResponseMessage> GetSampleExclude(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "samples/exclude")] HttpRequestMessage req,
+            ILogger log)
+        {
+            var result = await Factory.Create<ISampleHttpFunction, ILogger>(log)
+                                      .InvokeAsync<HttpRequestMessage, HttpResponseMessage>(req)
+                                      .ConfigureAwait(false);
+
+            return result;
+        }
+
+        /// <summary>
         /// Invokes the HTTP trigger endpoint to create sample.
         /// </summary>
         /// <param name="req"><see cref="HttpRequestMessage"/> instance.</param>

--- a/src/Aliencube.AzureFunctions.FunctionAppV2/OpenApiHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV2/OpenApiHttpTrigger.cs
@@ -39,7 +39,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
             string extension,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions("v2", extension, Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions("v2", extension, Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequest, IActionResult>(req, options)
                                       .ConfigureAwait(false);
@@ -63,7 +64,8 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
             string extension,
             ILogger log)
         {
-            var options = new RenderOpeApiDocumentFunctionOptions(version, extension, Assembly.GetExecutingAssembly());
+            string[] excludedTags = GetExcludedTagsFromQueryString(req);
+            var options = new RenderOpeApiDocumentFunctionOptions(version, extension, Assembly.GetExecutingAssembly(), excludedTags);
             var result = await Factory.Create<IRenderOpeApiDocumentFunction, ILogger>(log)
                                       .InvokeAsync<HttpRequest, IActionResult>(req, options)
                                       .ConfigureAwait(false);
@@ -89,6 +91,18 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
                                       .ConfigureAwait(false);
 
             return result;
+        }
+
+        private static string[] GetExcludedTagsFromQueryString(HttpRequest req)
+        {
+            string[] excludedTags = null;
+            string excludedTagsQueryString = req.Query["excludedTags"];
+            if (!string.IsNullOrWhiteSpace(excludedTagsQueryString))
+            {
+                excludedTags = excludedTagsQueryString.Split(',');
+            }
+
+            return excludedTags;
         }
     }
 }

--- a/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
+++ b/src/Aliencube.AzureFunctions.FunctionAppV2/SampleHttpTrigger.cs
@@ -67,6 +67,24 @@ namespace Aliencube.AzureFunctions.FunctionAppV2
         }
 
         /// <summary>
+        /// Invokes the HTTP trigger endpoint to get sample but exclude from tags.
+        /// </summary>
+        /// <param name="req"><see cref="HttpRequest"/> instance.</param>
+        /// <param name="log"><see cref="ILogger"/> instance.</param>
+        [FunctionName(nameof(GetSampleExclude))]
+        [OpenApiOperation(operationId: "exclude", tags: new[] { "exclude" }, Summary = "Used for tag exclusion", Description = "Used for tag exclusion.", Visibility = OpenApiVisibilityType.Important)]
+        public static async Task<IActionResult> GetSampleExclude(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "samples/exclude")] HttpRequest req,
+            ILogger log)
+        {
+            var result = await Factory.Create<ISampleHttpFunction, ILogger>(log)
+                                      .InvokeAsync<HttpRequest, IActionResult>(req)
+                                      .ConfigureAwait(false);
+
+            return result;
+        }
+
+        /// <summary>
         /// Invokes the HTTP trigger endpoint to create sample.
         /// </summary>
         /// <param name="req"><see cref="HttpRequest"/> instance.</param>


### PR DESCRIPTION
Add optional query string parameter to filter out operations that have a particular tags.
Excluded tags can be comma separated. 